### PR TITLE
feat(edit-company) add company edit feature and responsive for mobile

### DIFF
--- a/src/@types/CompanyTypes.ts
+++ b/src/@types/CompanyTypes.ts
@@ -1,0 +1,9 @@
+export type Company = {
+  id: number;
+  name: string;
+  cnpj: string;
+  tradeName: string;
+  address: string;
+  createdAt: string;
+  updatedAt: string;
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ function App() {
           <AppRoutes />
         </Box>
       </Container>
-      <ToastContainer />
+      <ToastContainer draggable position="bottom-right" />
     </ThemeProvider>
   );
 }

--- a/src/components/CustomExpandableTable.tsx
+++ b/src/components/CustomExpandableTable.tsx
@@ -1,0 +1,95 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  IconButton,
+  Collapse,
+  Box,
+  Paper,
+} from '@mui/material';
+import { KeyboardArrowDown, KeyboardArrowUp } from '@mui/icons-material';
+import React, { useState } from 'react';
+import CustomTypography from './CustomTypography';
+
+interface CustomExpandableTableProps<T> {
+  rows: T[];
+  columns: string[];
+  getRowId: (row: T) => string | number;
+  renderMainRow: (
+    row: T,
+    toggle: () => void,
+    isOpen: boolean,
+  ) => React.ReactNode;
+  renderCollapseContent: (row: T) => React.ReactNode;
+}
+
+export function CustomExpandableTable<T>({
+  rows,
+  columns,
+  getRowId,
+  renderMainRow,
+  renderCollapseContent,
+}: CustomExpandableTableProps<T>) {
+  const [openRows, setOpenRows] = useState<Record<string | number, boolean>>(
+    {},
+  );
+
+  const toggleRow = (id: string | number) => {
+    setOpenRows((prev) => ({
+      ...prev,
+      [id]: !prev[id],
+    }));
+  };
+
+  return (
+    <TableContainer component={Paper} sx={{ mt: 4 }}>
+      <CustomTypography variant="h5" textAlign="center" mt={2}>
+        Lista de Registros
+      </CustomTypography>
+
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell />
+            {columns.map((column) => (
+              <TableCell key={column}>{column}</TableCell>
+            ))}
+            <TableCell>Ações</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row) => {
+            const rowId = getRowId(row);
+            const isOpen = openRows[rowId] || false;
+
+            return (
+              <React.Fragment key={rowId}>
+                <TableRow>
+                  <TableCell>
+                    <IconButton size="small" onClick={() => toggleRow(rowId)}>
+                      {isOpen ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+                    </IconButton>
+                  </TableCell>
+                  {renderMainRow(row, () => toggleRow(rowId), isOpen)}
+                </TableRow>
+                <TableRow>
+                  <TableCell
+                    style={{ paddingBottom: 0, paddingTop: 0 }}
+                    colSpan={columns.length + 2}
+                  >
+                    <Collapse in={isOpen} timeout="auto" unmountOnExit>
+                      <Box sx={{ margin: 2 }}>{renderCollapseContent(row)}</Box>
+                    </Collapse>
+                  </TableCell>
+                </TableRow>
+              </React.Fragment>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/components/CustomGrid.tsx
+++ b/src/components/CustomGrid.tsx
@@ -1,4 +1,3 @@
-// src/components/CustomGrid.tsx
 import { Grid, GridProps } from '@mui/material';
 
 export default function CustomGrid({

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,30 @@
-import { AppBar, Toolbar, Box, Button } from '@mui/material';
+import { AppBar, Toolbar, Box, Button, IconButton } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
 import { Link as RouterLink } from 'react-router-dom';
+import { useState } from 'react';
+
 import CustomTypography from './CustomTypography';
 import { ThemeToggleButton } from './ThemeToggleButton';
+import { useBreakpoints } from '../hooks/useBreakpoints';
+import MobileDrawer from './MobileDrawer';
+
 import {
   ROUTE_EMPRESAS,
   ROUTE_EMPRESAS_CADASTRAR,
   ROUTE_HOME,
 } from '../constants/headerRoutes';
 
+const navLinks = [
+  { label: 'Listar Empresas', to: ROUTE_EMPRESAS },
+  { label: 'Cadastrar Empresa', to: ROUTE_EMPRESAS_CADASTRAR },
+];
+
 export default function Header() {
+  const { isMobile } = useBreakpoints();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const toggleDrawer = (open: boolean) => () => setDrawerOpen(open);
+
   return (
     <AppBar position="static" color="primary" elevation={1}>
       <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -21,20 +37,33 @@ export default function Header() {
           Projeto Empresas - KPMG
         </CustomTypography>
 
-        <Box sx={{ display: 'flex', gap: 2 }}>
-          <Button component={RouterLink} to={ROUTE_EMPRESAS} color="inherit">
-            Listar Empresas
-          </Button>
-          <Button
-            component={RouterLink}
-            to={ROUTE_EMPRESAS_CADASTRAR}
-            color="inherit"
-          >
-            Cadastrar Empresa
-          </Button>
+        {isMobile ? (
+          <>
+            <IconButton
+              edge="end"
+              color="inherit"
+              aria-label="menu"
+              onClick={toggleDrawer(true)}
+            >
+              <MenuIcon />
+            </IconButton>
 
-          <ThemeToggleButton />
-        </Box>
+            <MobileDrawer
+              open={drawerOpen}
+              onClose={toggleDrawer(false)}
+              links={navLinks}
+            />
+          </>
+        ) : (
+          <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
+            {navLinks.map(({ label, to }) => (
+              <Button key={to} component={RouterLink} to={to} color="inherit">
+                {label}
+              </Button>
+            ))}
+            <ThemeToggleButton />
+          </Box>
+        )}
       </Toolbar>
     </AppBar>
   );

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -1,0 +1,47 @@
+import {
+  Box,
+  Drawer,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { ThemeToggleButton } from './ThemeToggleButton';
+
+interface MobileDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  links: { label: string; to: string }[];
+}
+
+export default function MobileDrawer({
+  open,
+  onClose,
+  links,
+}: MobileDrawerProps) {
+  return (
+    <Drawer anchor="bottom" open={open} onClose={onClose}>
+      <Box
+        sx={{ width: 250 }}
+        role="presentation"
+        onClick={onClose}
+        onKeyDown={onClose}
+      >
+        <List>
+          {links.map(({ label, to }) => (
+            <ListItem key={to} disablePadding>
+              <ListItemButton component={RouterLink} to={to}>
+                <ListItemText primary={label} />
+              </ListItemButton>
+            </ListItem>
+          ))}
+
+          <ListItem>
+            <ThemeToggleButton />
+          </ListItem>
+        </List>
+      </Box>
+    </Drawer>
+  );
+}

--- a/src/hooks/company/useCompanyForm.ts
+++ b/src/hooks/company/useCompanyForm.ts
@@ -1,14 +1,30 @@
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useParams } from 'react-router-dom';
 
 import { CompanyFormData, companySchema } from '../../schemas/companySchema';
-
-import { findAddressByCep } from '../../services/viacepService';
-import { useCreateCompany } from '../../hooks/company/useCreateCompany';
 import { FormFieldsTypes } from '../../@types/FormFieldsTypes';
 
+import { findAddressByCep } from '../../services/viacepService';
+import {
+  createCompany,
+  getCompanyById,
+  updateCompany,
+} from '../../services/company/companyService';
+
+import { parseAddress } from '../../utils/formatStrings';
+import { useLoadingStore } from '../../stores/loading.store';
+import { toast } from 'react-toastify';
+import { useNavigate } from 'react-router-dom';
+import { ROUTE_EMPRESAS } from '../../constants/headerRoutes';
+import { handleAxiosError } from '../../utils/handleAxiosError';
+
 export function useCompanyForm() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const setLoading = useLoadingStore((state) => state.setLoading);
+
   const {
     handleSubmit,
     formState: { errors },
@@ -21,7 +37,6 @@ export function useCompanyForm() {
   });
 
   const cep = watch('cep');
-  const { mutate } = useCreateCompany();
 
   useEffect(() => {
     const fetchCep = async () => {
@@ -38,8 +53,62 @@ export function useCompanyForm() {
     if (cep) fetchCep();
   }, [cep, setValue, setFocus]);
 
-  const onSubmit = (data: CompanyFormData) => {
-    mutate(data);
+  useEffect(() => {
+    const fetchCompany = async () => {
+      if (!id) return;
+
+      setLoading(true);
+      try {
+        const company = await getCompanyById(id);
+        if (!company) return;
+
+        setValue('name', company.name);
+        setValue('cnpj', company.cnpj);
+        setValue('tradeName', company.tradeName);
+
+        const addressFields = parseAddress(company.address);
+        setValue('cep', addressFields.cep || '');
+        setValue('logradouro', addressFields.logradouro || '');
+        setValue('numero', addressFields.numero || '');
+        setValue('complemento', addressFields.complemento || '');
+        setValue('bairro', addressFields.bairro || '');
+        setValue('municipio', addressFields.municipio || '');
+        setValue('estado', addressFields.estado || '');
+      } catch (error: unknown) {
+        toast.error('Erro ao carregar dados da empresa.');
+        handleAxiosError(
+          error,
+          'Um erro inesperado aconteceu, tente novamente mais tarde',
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCompany();
+  }, [id, setValue, setLoading]);
+
+  const onSubmit = async (data: CompanyFormData) => {
+    setLoading(true);
+    try {
+      if (id) {
+        await updateCompany(id, data);
+        toast.success('Empresa atualizada com sucesso!');
+      } else {
+        await createCompany(data);
+        toast.success(
+          'Empresa criada com sucesso! Você será redirecionado para a página de empresas.',
+        );
+      }
+      navigate(ROUTE_EMPRESAS);
+    } catch (error) {
+      handleAxiosError(
+        error,
+        `Erro ao ${id ? 'atualizar' : 'cadastrar'}  empresa.`,
+      );
+    } finally {
+      setLoading(false);
+    }
   };
 
   const formFields: FormFieldsTypes[] = [
@@ -61,5 +130,6 @@ export function useCompanyForm() {
     control,
     onSubmit,
     formFields,
+    isEditing: Boolean(id),
   };
 }

--- a/src/hooks/company/useCompanyForm.ts
+++ b/src/hooks/company/useCompanyForm.ts
@@ -3,9 +3,10 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 import { CompanyFormData, companySchema } from '../../schemas/companySchema';
-import { FormFieldsTypes } from '../../@types/FormFieldsTypes';
+
 import { findAddressByCep } from '../../services/viacepService';
-import { createCompany } from '../../services/company/companyService';
+import { useCreateCompany } from '../../hooks/company/useCreateCompany';
+import { FormFieldsTypes } from '../../@types/FormFieldsTypes';
 
 export function useCompanyForm() {
   const {
@@ -20,6 +21,7 @@ export function useCompanyForm() {
   });
 
   const cep = watch('cep');
+  const { mutate } = useCreateCompany();
 
   useEffect(() => {
     const fetchCep = async () => {
@@ -36,8 +38,8 @@ export function useCompanyForm() {
     if (cep) fetchCep();
   }, [cep, setValue, setFocus]);
 
-  const onSubmit = async (data: CompanyFormData) => {
-    await createCompany(data);
+  const onSubmit = (data: CompanyFormData) => {
+    mutate(data);
   };
 
   const formFields: FormFieldsTypes[] = [

--- a/src/hooks/company/useCreateCompany.ts
+++ b/src/hooks/company/useCreateCompany.ts
@@ -1,0 +1,41 @@
+import { toast } from 'react-toastify';
+import { useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useLoadingStore } from '../../stores/loading.store';
+import { ROUTE_EMPRESAS } from '../../constants/headerRoutes';
+import { createCompany } from '../../services/company/companyService';
+import { CompanyFormData } from '../../schemas/companySchema';
+import { handleAxiosError } from '../../utils/handleAxiosError';
+
+export const useCreateCompany = () => {
+  const queryClient = useQueryClient();
+  const setLoading = useLoadingStore((state) => state.setLoading);
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (data: CompanyFormData) => {
+      setLoading(true);
+      return createCompany(data);
+    },
+    onSuccess: () => {
+      toast.success(
+        'Empresa criada com sucesso! Você será redirecionado para a página de empresas.',
+      );
+      queryClient.invalidateQueries({ queryKey: ['companies'] });
+      setTimeout(() => {
+        navigate(ROUTE_EMPRESAS);
+      }, 4000);
+    },
+    onError: (error) => {
+      setLoading(false);
+      handleAxiosError(
+        error,
+        'Erro ao criar empresa. Verifique os dados e tente novamente.',
+      );
+    },
+    onSettled: () => {
+      setLoading(false);
+    },
+  });
+};

--- a/src/hooks/company/useFetchCompanies.ts
+++ b/src/hooks/company/useFetchCompanies.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../../libs/axios';
+
+export const useFetchCompanies = () => {
+  return useQuery({
+    queryKey: ['companies'],
+    queryFn: async () => {
+      const response = await api.get('/companies');
+      return response.data;
+    },
+  });
+};

--- a/src/hooks/company/useUpdateCompany.ts
+++ b/src/hooks/company/useUpdateCompany.ts
@@ -1,14 +1,14 @@
-import { toast } from 'react-toastify';
-import { useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 
-import { useLoadingStore } from '../../stores/loading.store';
-import { ROUTE_EMPRESAS } from '../../constants/headerRoutes';
-import { createCompany } from '../../services/company/companyService';
 import { CompanyFormData } from '../../schemas/companySchema';
 import { handleAxiosError } from '../../utils/handleAxiosError';
+import { updateCompany } from '../../services/company/companyService';
+import { useLoadingStore } from '../../stores/loading.store';
+import { ROUTE_EMPRESAS } from '../../constants/headerRoutes';
 
-export const useCreateCompany = () => {
+export const useUpdateCompany = (id: string | number) => {
   const queryClient = useQueryClient();
   const setLoading = useLoadingStore((state) => state.setLoading);
   const navigate = useNavigate();
@@ -16,21 +16,16 @@ export const useCreateCompany = () => {
   return useMutation({
     mutationFn: (data: CompanyFormData) => {
       setLoading(true);
-      return createCompany(data);
+      return updateCompany(id, data);
     },
     onSuccess: () => {
-      toast.success(
-        'Empresa criada com sucesso! Você será redirecionado para a página de empresas.',
-      );
+      toast.success('Empresa atualizada com sucesso!');
       queryClient.invalidateQueries({ queryKey: ['companies'] });
       navigate(ROUTE_EMPRESAS);
     },
     onError: (error) => {
       setLoading(false);
-      handleAxiosError(
-        error,
-        'Erro ao criar empresa. Verifique os dados e tente novamente.',
-      );
+      handleAxiosError(error, 'Erro ao atualizar empresa.');
     },
     onSettled: () => {
       setLoading(false);

--- a/src/hooks/useBreakpoints.ts
+++ b/src/hooks/useBreakpoints.ts
@@ -1,0 +1,17 @@
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+export function useBreakpoints() {
+  const theme = useTheme();
+
+  return {
+    isXs: useMediaQuery(theme.breakpoints.only('xs')),
+    isSm: useMediaQuery(theme.breakpoints.only('sm')),
+    isMd: useMediaQuery(theme.breakpoints.only('md')),
+    isLg: useMediaQuery(theme.breakpoints.only('lg')),
+    isXl: useMediaQuery(theme.breakpoints.only('xl')),
+    isMobile: useMediaQuery(theme.breakpoints.down('sm')),
+    isTablet: useMediaQuery(theme.breakpoints.between('sm', 'md')),
+    isDesktop: useMediaQuery(theme.breakpoints.up('md')),
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,19 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import './index.css';
 import App from './App.tsx';
 
+const queryClient = new QueryClient();
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter future={{ v7_startTransition: true }}>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>,
 );

--- a/src/pages/CompanyFormPage.tsx
+++ b/src/pages/CompanyFormPage.tsx
@@ -1,6 +1,6 @@
 import { Controller } from 'react-hook-form';
 import { Button, Paper, Box, Grid } from '@mui/material';
-import { useCompanyForm } from '../hooks/company/useCompanyForm';
+import { useParams } from 'react-router-dom';
 
 import CustomGrid from '../components/CustomGrid';
 import CustomTextField from '../components/CustomTextField';
@@ -8,9 +8,13 @@ import CustomTypography from '../components/CustomTypography';
 import CustomCircularProgress from '../components/CustomCircularProgress';
 import MaskedTextField from '../components/MaskedTextField';
 import { CompanyFormData } from '../schemas/companySchema';
+import { useCompanyForm } from '../hooks/company/useCompanyForm';
 import { useLoadingStore } from '../stores/loading.store';
 
 export default function CompanyFormPage() {
+  const { id } = useParams(); // se tiver ID, está editando
+  const isEditMode = !!id;
+
   const { control, errors, handleSubmit, onSubmit, formFields } =
     useCompanyForm();
 
@@ -19,7 +23,7 @@ export default function CompanyFormPage() {
   return (
     <Paper elevation={3} sx={{ p: 4, mt: 4 }}>
       <CustomTypography preset="title" gutterBottom textAlign="center" mb={8}>
-        Cadastro de Empresas
+        {isEditMode ? 'Atualizar Empresa' : 'Cadastro de Empresas'}
       </CustomTypography>
 
       <Box
@@ -69,7 +73,13 @@ export default function CompanyFormPage() {
           disabled={isLoading}
           startIcon={isLoading ? <CustomCircularProgress /> : null}
         >
-          {isLoading ? 'Salvando...' : 'Salvar Empresa'}
+          {isLoading
+            ? isEditMode
+              ? 'Atualizando...'
+              : 'Salvando...'
+            : isEditMode
+              ? 'Alterar Empresa'
+              : 'Salvar Empresa'}
         </Button>
       </Box>
     </Paper>

--- a/src/pages/CompanyListPage.tsx
+++ b/src/pages/CompanyListPage.tsx
@@ -1,8 +1,69 @@
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { Edit } from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
+import { IconButton, Paper, TableCell } from '@mui/material';
+
+import { useFetchCompanies } from '../hooks/company/useFetchCompanies';
+import CustomTypography from '../components/CustomTypography';
+import { CustomExpandableTable } from '../components/CustomExpandableTable';
+
+import { Company } from '../@types/CompanyTypes';
+
 export default function CompanyListPage() {
-  return (
-    <div>
-      <h1>Lista de Empresas</h1>
-      <p>Esta é a página de listagem de empresas.</p>
-    </div>
+  const { data: companies = [] } = useFetchCompanies();
+  const navigate = useNavigate();
+
+  return !companies.length ? (
+    <Paper>
+      <CustomTypography variant="h6" textAlign="center" my={4}>
+        Nenhuma empresa cadastrada
+      </CustomTypography>
+    </Paper>
+  ) : (
+    <CustomExpandableTable<Company>
+      rows={companies}
+      columns={['ID', 'Nome', 'CNPJ']}
+      getRowId={(company) => company.id}
+      renderMainRow={(company) => (
+        <>
+          <TableCell>{company.id}</TableCell>
+          <TableCell>{company.name}</TableCell>
+          <TableCell>{company.cnpj}</TableCell>
+          <TableCell align="right">
+            <IconButton
+              aria-label="edit"
+              color="primary"
+              onClick={() => navigate(`/empresas/editar/${company.id}`)}
+            >
+              <Edit />
+            </IconButton>
+          </TableCell>
+        </>
+      )}
+      renderCollapseContent={(company) => (
+        <>
+          <CustomTypography variant="subtitle1" gutterBottom>
+            Detalhes
+          </CustomTypography>
+          <CustomTypography>
+            Nome Fantasia: {company.tradeName}
+          </CustomTypography>
+          <CustomTypography>Endereço: {company.address}</CustomTypography>
+          <CustomTypography>
+            Criada em:{' '}
+            {format(new Date(company.createdAt), 'dd/MM/yyyy HH:mm', {
+              locale: ptBR,
+            })}
+          </CustomTypography>
+          <CustomTypography>
+            Atualizada em:{' '}
+            {format(new Date(company.updatedAt), 'dd/MM/yyyy HH:mm', {
+              locale: ptBR,
+            })}
+          </CustomTypography>
+        </>
+      )}
+    />
   );
 }

--- a/src/pages/CompanyListPage.tsx
+++ b/src/pages/CompanyListPage.tsx
@@ -4,15 +4,20 @@ import { Edit } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { IconButton, Paper, TableCell } from '@mui/material';
 
+import { useBreakpoints } from '../hooks/useBreakpoints';
 import { useFetchCompanies } from '../hooks/company/useFetchCompanies';
 import CustomTypography from '../components/CustomTypography';
 import { CustomExpandableTable } from '../components/CustomExpandableTable';
 
 import { Company } from '../@types/CompanyTypes';
+import { toBrasiliaTime } from '../utils/dateFormater';
 
 export default function CompanyListPage() {
   const { data: companies = [] } = useFetchCompanies();
+  const { isMobile } = useBreakpoints();
   const navigate = useNavigate();
+
+  const columns = isMobile ? ['ID', 'Nome'] : ['ID', 'Nome', 'CNPJ'];
 
   return !companies.length ? (
     <Paper>
@@ -23,13 +28,13 @@ export default function CompanyListPage() {
   ) : (
     <CustomExpandableTable<Company>
       rows={companies}
-      columns={['ID', 'Nome', 'CNPJ']}
+      columns={columns}
       getRowId={(company) => company.id}
       renderMainRow={(company) => (
         <>
           <TableCell>{company.id}</TableCell>
           <TableCell>{company.name}</TableCell>
-          <TableCell>{company.cnpj}</TableCell>
+          {!isMobile && <TableCell>{company.cnpj}</TableCell>}
           <TableCell align="right">
             <IconButton
               aria-label="edit"
@@ -52,13 +57,13 @@ export default function CompanyListPage() {
           <CustomTypography>Endereço: {company.address}</CustomTypography>
           <CustomTypography>
             Criada em:{' '}
-            {format(new Date(company.createdAt), 'dd/MM/yyyy HH:mm', {
+            {format(toBrasiliaTime(company.createdAt), 'dd/MM/yyyy HH:mm', {
               locale: ptBR,
             })}
           </CustomTypography>
           <CustomTypography>
             Atualizada em:{' '}
-            {format(new Date(company.updatedAt), 'dd/MM/yyyy HH:mm', {
+            {format(toBrasiliaTime(company.updatedAt), 'dd/MM/yyyy HH:mm', {
               locale: ptBR,
             })}
           </CustomTypography>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,6 @@
-// src/pages/HomePage.tsx
-import { Box, Paper } from "@mui/material";
+import { Box, Paper } from '@mui/material';
 
-import CustomTypography from "../components/CustomTypography";
+import CustomTypography from '../components/CustomTypography';
 
 export default function HomePage() {
   return (

--- a/src/services/company/companyService.ts
+++ b/src/services/company/companyService.ts
@@ -1,21 +1,11 @@
-import { toast } from 'react-toastify';
-
 import api from '../../libs/axios';
 import { CompanyFormData } from '../../schemas/companySchema';
 import { omitFields } from '../../utils/omitFields';
-import { handleAxiosError } from '../../utils/handleAxiosError';
-import { useLoadingStore } from '../../stores/loading.store';
 import { formatAddress } from '../../utils/formatStrings';
-import { ROUTE_EMPRESAS } from '../../constants/headerRoutes';
 
 /**
  * @function createCompany
- * @param {CompanyFormData} formData - The form data from the company form
- * @returns Response from the API
- * @description This function is responsible for creating a new company in the system.
- * It receives the form data, formats the address, removes address-related fields,
- * and sends a POST request to the API.
- * The address is formatted as "logradouro, numero - complemento, bairro, municipio - estado, CEP: cep".
+ * @description Formats and sends a POST request to create a company.
  */
 export const createCompany = async (formData: CompanyFormData) => {
   const address = formatAddress(formData);
@@ -33,29 +23,15 @@ export const createCompany = async (formData: CompanyFormData) => {
     address,
   };
 
-  const setLoading = useLoadingStore.getState().setLoading;
+  const { data } = await api.post('/companies', payload);
+  return data;
+};
 
-  try {
-    setLoading(true);
-
-    const { data } = await api.post('/companies', payload);
-    toast.success(
-      'Empresa criada com sucesso! Você será redirecionado para a página de empresas.',
-    );
-    // Redirect to the companies page after 4 seconds
-    // allows the user to see the success message
-    // before being redirected
-    setTimeout(() => {
-      window.location.href = ROUTE_EMPRESAS;
-    }, 4000);
-
-    return data;
-  } catch (error) {
-    handleAxiosError(
-      error,
-      'Erro ao criar empresa. Verifique os dados e tente novamente.',
-    );
-  } finally {
-    setLoading(false);
-  }
+/**
+ * @function getCompanies
+ * @description Fetches all companies from the API.
+ */
+export const getCompanies = async () => {
+  const { data } = await api.get('/companies');
+  return data;
 };

--- a/src/services/company/companyService.ts
+++ b/src/services/company/companyService.ts
@@ -35,3 +35,31 @@ export const getCompanies = async () => {
   const { data } = await api.get('/companies');
   return data;
 };
+
+export const getCompanyById = async (id: string | number) => {
+  const { data } = await api.get(`/companies/${id}`);
+  return data;
+};
+
+export const updateCompany = async (
+  id: string | number,
+  formData: CompanyFormData,
+) => {
+  const address = formatAddress(formData);
+
+  const payload = {
+    ...omitFields(formData, [
+      'logradouro',
+      'numero',
+      'complemento',
+      'bairro',
+      'municipio',
+      'estado',
+      'cep',
+    ]),
+    address,
+  };
+
+  const { data } = await api.patch(`/companies/${id}`, payload);
+  return data;
+};

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,4 +1,3 @@
-// src/theme/getTheme.ts
 import { createTheme, PaletteMode } from '@mui/material';
 
 const commonSettings = {

--- a/src/utils/dateFormater.ts
+++ b/src/utils/dateFormater.ts
@@ -1,0 +1,4 @@
+import { addHours } from 'date-fns';
+
+export const toBrasiliaTime = (date: string | Date) =>
+  addHours(new Date(date), -3);

--- a/src/utils/formatStrings.ts
+++ b/src/utils/formatStrings.ts
@@ -1,7 +1,53 @@
 import { CompanyFormData } from '../schemas/companySchema';
 
-export const formatAddress = (data: CompanyFormData) => {
+export const formatAddress = (data: CompanyFormData): string => {
   return `${data.logradouro}, ${data.numero}${
     data.complemento ? ' - ' + data.complemento : ''
   }, ${data.bairro}, ${data.municipio} - ${data.estado}, CEP: ${data.cep}`;
 };
+export function parseAddress(address: string) {
+  const result = {
+    logradouro: '',
+    numero: '',
+    complemento: '',
+    bairro: '',
+    municipio: '',
+    estado: '',
+    cep: '',
+  };
+
+  if (!address) return result;
+
+  const parts = address.split(',').map((part) => part.trim());
+
+  // Extrai o CEP
+  const cepMatch = parts[parts.length - 1]?.match(/CEP:\s*(\d{5}-\d{3})/);
+  if (cepMatch) {
+    result.cep = cepMatch[1];
+    parts.pop();
+
+    // Extrai município e estado
+    const municipioEstado = parts.pop();
+    if (municipioEstado?.includes(' - ')) {
+      const [municipio, estado] = municipioEstado.split(' - ');
+      result.municipio = municipio.trim();
+      result.estado = estado.trim();
+    }
+
+    result.logradouro = parts[0] || '';
+
+    // Trata número e complemento juntos
+    if (parts[1]?.includes(' - ')) {
+      const [numero, complemento] = parts[1].split(' - ');
+      result.numero = numero.trim();
+      result.complemento = complemento.trim();
+    } else {
+      result.numero = parts[1] || '';
+    }
+
+    // Bairro sempre no final restante
+    result.bairro = parts[parts.length - 1] || '';
+  }
+
+  return result;
+}


### PR DESCRIPTION
## 📦 Description

This PR introduces two main improvements:
- ✏️ **Edit company feature**: Users can now update company data, triggering an email notification (HTML template).
- 📱 **Responsive layout**: Improved mobile experience with collapsible tables and a responsive navigation drawer.

---

## 🛠 Main Changes

- Added support for editing companies via `/companies/:id` route
- Implemented mobile-friendly expandable table (`CustomExpandableTable`)
- Added responsive navigation with a hamburger menu (`MobileDrawer`)
- Automatically parses address when editing existing companies
- Added timezone adjustment for displaying creation/update timestamps (UTC → BRT)

---

## 🔍 Tests

- [x] Manual browser test (desktop & mobile)
- [x] API integration: edit company → triggers email and updates data
- [x] Mobile table hides CNPJ column correctly
